### PR TITLE
Ngx-translate implementation 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "eslint": "^8.6.0",
         "jasmine-core": "~3.10.0",
         "jsonld-streaming-parser": "^2.1.0",
-        "karma": "~6.3.14",
+        "karma": "~6.3.16",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage": "~2.1.0",
         "karma-jasmine": "~4.0.0",
@@ -8949,9 +8949,9 @@
       ]
     },
     "node_modules/karma": {
-      "version": "6.3.14",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.14.tgz",
-      "integrity": "sha512-SDFoU5F4LdosEiUVWUDRPCV/C1zQRNtIakx7rWkigf7R4sxGADlSEeOma4S1f/js7YAzvqLW92ByoiQptg+8oQ==",
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.16.tgz",
+      "integrity": "sha512-nEU50jLvDe5yvXqkEJRf8IuvddUkOY2x5Xc4WXHz6dxINgGDrgD2uqQWeVrJs4hbfNaotn+HQ1LZJ4yOXrL7xQ==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -8969,6 +8969,7 @@
         "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
@@ -9080,6 +9081,18 @@
       "dev": true,
       "dependencies": {
         "source-map-support": "^0.5.5"
+      }
+    },
+    "node_modules/karma/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/karma/node_modules/source-map": {
@@ -20679,9 +20692,9 @@
       "dev": true
     },
     "karma": {
-      "version": "6.3.14",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.14.tgz",
-      "integrity": "sha512-SDFoU5F4LdosEiUVWUDRPCV/C1zQRNtIakx7rWkigf7R4sxGADlSEeOma4S1f/js7YAzvqLW92ByoiQptg+8oQ==",
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.16.tgz",
+      "integrity": "sha512-nEU50jLvDe5yvXqkEJRf8IuvddUkOY2x5Xc4WXHz6dxINgGDrgD2uqQWeVrJs4hbfNaotn+HQ1LZJ4yOXrL7xQ==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
@@ -20699,6 +20712,7 @@
         "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
@@ -20709,6 +20723,15 @@
         "yargs": "^16.1.1"
       },
       "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "^8.6.0",
     "jasmine-core": "~3.10.0",
     "jsonld-streaming-parser": "^2.1.0",
-    "karma": "~6.3.14",
+    "karma": "~6.3.16",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.1.0",
     "karma-jasmine": "~4.0.0",

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -67,6 +67,10 @@
     </li>
     <li><a href="https://rhizomer.rhizomik.net/datasets/dbpedia" target="_blank">DBPedia</a>
     </li>
+    <li><a href="https://rhizomik.net" target="_blank">Rhizomik Initiative website</a>
+    </li>
+    <li><a href="https://rhizomer.rhizomik.net/datasets/xkcd" target="_blank">XKCD</a>
+    </li>
   </ul>
   <p>If you are interested in testing Rhizomer with your own data, you can request and account: <a
     href="mailto:contact@rhizomik.net" target="_blank">contact@rhizomik.net</a></p>

--- a/src/app/dataset/dataset-form/dataset-form.component.html
+++ b/src/app/dataset/dataset-form/dataset-form.component.html
@@ -25,12 +25,13 @@
 
           <!-- Query Type input -->
           <div class="form-group">
-            <label class="control-label" for="queryType">Query Type ("Optimized" is recommended for large datasets)</label>
+            <label class="control-label" for="queryType">Query Type</label>
             <select id="queryType" name="queryType" class="form-control" required
                     [(ngModel)]="dataset.queryType">
               <option [value]="'OPTIMIZED'">Optimized</option>
               <option [value]="'DETAILED'">Detailed</option>
             </select>
+            <div class="small">"Optimized" is recommended for large datasets, "Detailed" enables network overview.</div>
           </div>
 
           <!-- Button -->


### PR DESCRIPTION
Added internationalization library @ngx-translate/core to rhizomerEye. Current languages are Catalan, Spanish and English, with the option of adding any language to the list. Dynamic content (content fetched from database) cannot be directly translated by ngx-translate. 